### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/swift-rt/src/metadata/tuple/labels/mod.rs
+++ b/swift-rt/src/metadata/tuple/labels/mod.rs
@@ -32,19 +32,19 @@ impl PartialEq for TupleMetadataLabels {
         }
 
         loop {
-            unsafe {
-                match (*this, *other) {
+            
+                match unsafe {(*this, *other)} {
                     (0, 0) => return true,
 
                     (a, b) if a == b => {
-                        this = this.add(1);
-                        other = other.add(1);
+                        this = unsafe {this.add(1)};
+                        other = unsafe {other.add(1)};
                     }
 
                     // This case handles either being 0.
                     _ => return false,
                 }
-            }
+            
         }
     }
 }

--- a/swift/src/string/mod.rs
+++ b/swift/src/string/mod.rs
@@ -27,8 +27,8 @@ impl Clone for String {
     fn clone(&self) -> Self {
         let metadata = Self::get_metadata().as_metadata();
 
+        let mut clone = MaybeUninit::<Self>::uninit();
         unsafe {
-            let mut clone = MaybeUninit::<Self>::uninit();
             metadata.vw_initialize_with_copy(clone.as_mut_ptr(), self);
             clone.assume_init()
         }

--- a/swift/src/ty.rs
+++ b/swift/src/ty.rs
@@ -93,13 +93,13 @@ impl AnyType {
     #[inline]
     #[doc(alias = "swift_dynamicCastMetatype")]
     pub fn as_ty(self, other: AnyType) -> Option<AnyType> {
-        unsafe {
-            let result = casting::swift_dynamicCastMetatype(
+        
+            let result = unsafe { casting::swift_dynamicCastMetatype(
                 self.metadata().as_raw(),
                 other.metadata().as_raw(),
-            );
+            ) };
             Some(AnyType(NonNull::new(result as *mut Metadata)?))
-        }
+        
     }
 
     /// Returns `true` if this type as a kind of `other`.


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html