### PR TITLE
Parse framework TBD (yaml) files in swift-bindgen crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
     "swift",
     "swift-bindgen",
+    "swift-demangle",
     "swift-rt",
     "swift-sys",
 ]
+resolver = "2"

--- a/swift-bindgen/Cargo.toml
+++ b/swift-bindgen/Cargo.toml
@@ -8,6 +8,11 @@ readme = "../README.md"
 homepage = "https://github.com/rustswift/swift-bindgen"
 repository = "https://github.com/rustswift/swift-bindgen"
 documentation = "https://docs.rs/swift-bindgen"
-edition = "2018"
+edition = "2021"
 keywords = ["swift", "bindgen"]
 categories = ["api-bindings", "development-tools::ffi"]
+
+[dependencies]
+swift-demangle = { path = "../swift-demangle" }
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"

--- a/swift-bindgen/src/lib.rs
+++ b/swift-bindgen/src/lib.rs
@@ -14,3 +14,47 @@
 
 #![warn(missing_docs)]
 #![allow(clippy::module_inception)]
+
+/* EXAMPLE TBD FILE SNIPPET:
+tbd-version:     4
+targets:         [ armv7-ios, armv7s-ios, arm64-ios, arm64e-ios ]
+install-name:    '/usr/lib/swift/libswiftCore.dylib'
+current-version: 5.9.2
+swift-abi-version: 7
+exports:
+  - targets:         [ armv7-ios, armv7s-ios ]
+    symbols:         [ '_$sSi12SIMD2StorageV6_valueBi32_Bv2_vM', '_$sSi12SIMD2StorageV6_valueBi32_Bv2_vg',
+    ]
+    objc-classes:    [ _TtCs19__SwiftNativeNSData, __SwiftNativeNSDataBase, __SwiftNativeNSIndexSetBase ]
+*/
+
+use serde::Deserialize;
+#[derive(Deserialize)]
+struct TBD {
+    #[serde(rename = "tbd-version")]
+    tbd_version: u32,
+    targets: Vec<String>,
+    #[serde(rename = "install-name")]
+    install_name: String,
+    #[serde(rename = "current-version")]
+    current_version: String,
+    #[serde(rename = "swift-abi-version")]
+    swift_abi_version: u32,
+    exports: Vec<TBDExports>,
+}
+#[derive(Deserialize)]
+struct TBDExports {
+    targets: Vec<String>,
+    symbols: Vec<String>,
+    #[serde(rename = "objc-classes")]
+    objc_classes: Option<Vec<String>>
+}
+use std::fs;
+use std::error::Error;
+#[test]
+fn test_parse_tbd() {
+    let libswiftCorePath = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk/usr/lib/swift/libswiftCore.tbd";
+    let yaml: String = fs::read_to_string(libswiftCorePath).expect("Failed to read file");
+
+    let deserialized_point: TBD = serde_yaml::from_str(&yaml).expect("Failed to deserialize yaml");
+}

--- a/swift-demangle/Cargo.toml
+++ b/swift-demangle/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "swift-demangle"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/swift-demangle/build.rs
+++ b/swift-demangle/build.rs
@@ -1,0 +1,23 @@
+use std::{
+    process::Command,
+    path::PathBuf,
+    env,
+};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("env variable OUT_DIR not found"));
+    let out_swift = out_dir.join("libswiftDemangle.a");
+    let swiftc = Command::new("swiftc")
+        .arg("-static")
+        .arg("-o")
+        .arg(out_swift)
+        .arg("-emit-library")
+        .arg("./src/demangle.swift")
+        .output()
+        .expect("Failed to compile swift library");
+    if !swiftc.status.success() {
+        let stderr = String::from_utf8_lossy(&swiftc.stderr);
+        panic!("{}", stderr);
+    }
+    println!("cargo:rustc-link-search={}", out_dir.display());
+    Ok(())
+}

--- a/swift-demangle/src/demangle.swift
+++ b/swift-demangle/src/demangle.swift
@@ -1,0 +1,32 @@
+import Darwin
+import Foundation
+
+typealias Swift_Demangle = @convention(c) (_ mangledName: UnsafePointer<UInt8>?,
+                                           _ mangledNameLength: Int,
+                                           _ outputBuffer: UnsafeMutablePointer<UInt8>?,
+                                           _ outputBufferSize: UnsafeMutablePointer<Int>?,
+                                           _ flags: UInt32) -> UnsafeMutablePointer<Int8>?
+
+func swift_demangle(_ mangled: String) -> String? {
+    let RTLD_DEFAULT = dlopen(nil, RTLD_NOW)
+    if let sym = dlsym(RTLD_DEFAULT, "swift_demangle") {
+        let f = unsafeBitCast(sym, to: Swift_Demangle.self)
+        if let cString = f(mangled, mangled.count, nil, nil, 0) {
+            defer { cString.deallocate() }
+            return String(cString: cString)
+        }
+    }
+    return nil
+}
+
+@_cdecl("swift_demangle")
+func ffi_swift_demangle(_ mangled: UnsafePointer<CChar>) -> UnsafePointer<CChar>? {
+    let mangled  = String(cString: UnsafePointer<CChar>(mangled))
+
+    if let demangled = swift_demangle(mangled) {
+        return (demangled as NSString).utf8String
+    } else {
+        return nil
+    }
+}
+

--- a/swift-demangle/src/lib.rs
+++ b/swift-demangle/src/lib.rs
@@ -1,0 +1,28 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+#[link(name = "swiftDemangle")]
+extern "C" {
+    fn swift_demangle(s: *const c_char) -> *const c_char;
+}
+
+pub fn demangle(mangled: String) -> Option<String> {
+    let mangled = CString::new(mangled).expect("CString::new failed");
+    let demangled = unsafe{ swift_demangle(mangled.as_ptr()) };
+    if demangled == 0x0 as *const i8{
+        return None;
+    }
+    let demangled = unsafe{ CStr::from_ptr(demangled)};
+    Some(demangled.to_str().ok()?.to_string())
+}
+
+#[test]
+fn test_demangle() {
+    let out = demangle("foo".into());
+    assert!(out.is_none());
+
+    let out = demangle("$sSasSQRzlE2eeoiySbSayxG_ABtFZ".into());
+    println!("rust OUT: {out:?}");
+    assert!(out.is_some());
+    assert_eq!(out, Some("static (extension in Swift):Swift.Array<A where A: Swift.Equatable>.== infix(Swift.Array<A>, Swift.Array<A>) -> Swift.Bool".to_string()));
+}

--- a/swift-rt/Cargo.toml
+++ b/swift-rt/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 homepage = "https://github.com/rustswift/swift-bindgen"
 repository = "https://github.com/rustswift/swift-bindgen"
 documentation = "https://docs.rs/swift-rt"
-edition = "2018"
+edition = "2021"
 keywords = ["swift", "bindgen", "runtime"]
 categories = ["api-bindings", "development-tools::ffi"]
 

--- a/swift-sys/Cargo.toml
+++ b/swift-sys/Cargo.toml
@@ -8,10 +8,10 @@ readme = "../README.md"
 homepage = "https://github.com/rustswift/swift-bindgen"
 repository = "https://github.com/rustswift/swift-bindgen"
 documentation = "https://docs.rs/swift-sys"
-edition = "2018"
+edition = "2021"
 keywords = ["swift", "bindgen", "runtime"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 
 [features]
-default = []
+default = ["link"]
 link = []

--- a/swift/Cargo.toml
+++ b/swift/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 homepage = "https://github.com/rustswift/swift-bindgen"
 repository = "https://github.com/rustswift/swift-bindgen"
 documentation = "https://docs.rs/swift"
-edition = "2018"
+edition = "2021"
 keywords = ["swift", "bindgen", "stdlib"]
 categories = ["abi-bindings", "development-tools::ffi"]
 


### PR DESCRIPTION
There's a good chance this isn't the correct approach but I'm gonna give it a try. 

I've decided to take a look at the Swift `tbd` files. These are basically headers for dylibs in yaml form. Things like `libswiftCore.tbd` have a bunch of mangled names. To demangle the names, I use a swift function to get the demangled name, I call this function from rust but compile the swift source for that in a build script.